### PR TITLE
minor changes, improving file import, callback and event functionality

### DIFF
--- a/editor/test/js/SpriteMap.js
+++ b/editor/test/js/SpriteMap.js
@@ -1,0 +1,111 @@
+const   fsp = require ( 'fs/promises' ),
+        zlib = require ( 'zlib' );
+
+/**
+  * Loads a Sprite Engine area map consisting of one or more map layers built
+  * from a set of tiles.
+  *
+  * SpriteMap file format:
+  * extension - .spm
+  * signature - "SPRENGMAP"
+  * width - <int32> width in tiles ( total width is mapWidth * tileWidth )
+  * height - <int32> height in tiles ( total height is mapHeight * tileHeight )
+  * layers - <unit8> number of layers ( layer size is mapWidth * mapHeight )
+  * tile count - <unit8> number of tiles ( 16x16 indexed )
+  * palette length - <uint8> number of palette colors ( uint8 RGBA )
+  * packed data - <uint8> buffer of layers, tiles, palette colors
+  */
+
+    module.exports = class SpriteMap extends EventTarget {
+        static SIGNATURE_SIZE = 9;
+        static SIGNATURE = 'SPRENGMAP';
+        static TILE_SIZE = 256;
+        static COLOR_SIZE = 4;
+
+        static fromBuffer ( buffer ) {
+            let view = new DataView ( buffer ),
+             position = 0,
+             signature =  String.fromCharCodes ( ...new Uint8Array ( buffer.slice ( 0, SpriteSet.SIGNATURE_SIZE ) ) );
+            if ( singature === SpriteMap.SIGNATURE ) {
+                position += signature.length;
+                return new Promise ( ( resolve, reject ) => {
+                    let mapWidth = view.getInt32 ( ( position += 4 ) - 4 ),
+                        mapHeight = view.getInt32 ( ( position += 4 ) - 4 ),
+                        layersCount = view.getUint8 ( position++ ),
+                        tileCount = view.getUint8 ( position++ ),
+                        paletteLen = view.getUint8 ( position++ ),
+                        packed = buffer.slice ( position );
+
+                    zlib.deflateRaw ( packed, ( err, data ) => {
+                        if ( err ) reject ( err );
+
+                        let spriteMap = new SpriteMap (),
+                            i, position = 0;
+                            spriteMap.width = width;
+                            spriteMap.height = height;
+                            spriteMap.layers = [];
+                        for ( i = 0; i < layersCount; i += 1 ) {
+                            spriteMap.layers.push (
+                                new Uint8Array (
+                                    data.buffer.slice ( position, ( position += ( i + 1 ) * mapWidth * mapHeight ) )
+                                )
+                            );
+                        }
+                        spriteMap.tiles = [];
+                        for ( i = 0; i < tileCount; i += 1 ) {
+                            spriteMap.tiles.push (
+                                new Uint8Array (
+                                    data.buffer.slice ( position, ( position += ( i + 1 ) * SpriteMap.TILE_SIZE ) )
+                                )
+                            );
+                        }
+                        spriteMap.palette = [];
+                        for ( i = 0; i < paletteLen; i += 1 ) {
+                            spriteMap.palette.push (
+                                new Uint8Array (
+                                    data.buffer.slice ( position, ( position += ( i + 1 ) * SpriteMap.COLOR_SIZE ) )
+                                )
+                            );
+                        }
+
+                        spriteMap.dispatchEvent ( new Event ( 'load' ) );
+
+                        resolve ( spriteMap );
+                    } );
+                } )
+            } else {
+                throw new TypeError ( `SpriteMap: invalid file signature - "${signature}"` );
+            }
+        }
+
+        #complete = false;
+
+        constructor ( src ) {
+            super ();
+
+            if ( typeof src === 'string' ) {
+                fsp.readFile ( src ).then ( data => {
+                    SpriteMap.fromBuffer ( data.buffer ).then ( spriteMap => {
+                        Object.assign ( this, spriteMap );
+                        this.dispatchEvent ( new Event ( 'load' ) );
+                    } );
+                } );
+            }
+
+            this.width = 0;
+            this.height = 0;
+            this.layers = null;
+            this.tiles = null;
+            this.palette = null;
+
+            this.addEventListener ( 'load', event => this.#complete = true );
+        }
+
+        get complete () {
+            return this.#complete;
+        }
+
+        get ( x, y, width = 1, height = 1, depth = 1 ) {
+
+        }
+ }

--- a/editor/test/js/SpriteSet.js
+++ b/editor/test/js/SpriteSet.js
@@ -7,12 +7,18 @@ const fsp = require ( 'fs/promises' );
   * extension - .sps
   * signature - "SPRENGSET"
   * layout type - <byte> 0 (defualt) positioned, 1 fixed
-  * tile count - <int32>
   * position count - <int32>
-  * tile data - <uint8>
+  * packed position size - <int32>
+  * tile count - <int32>
+  * packed tile size <int32>
+  * palette length - <uint8>
+  * packed palette size - <int32>
+  * packed position data - <unit8>
+  * packed tile data - <uint8>
+  * packed palette data - <uint8>
   */
 
-class SpriteSet {
+class SpriteSet extends EventTarget {
     static POSITIONED = 0;
     static FIXED = 1;
     static TYPE = {
@@ -25,7 +31,7 @@ class SpriteSet {
             position = 0,
             signature =  String.fromCharCodes ( ...uint8.slice ( 0, 9 ) );
         if ( singature === 'SPRENGSET' ) {
-            position += 9;
+            position += signature.length;
             let view = new DataView ( data.buffer ),
                 spriteSet = new SpriteSet (),
                 layout = view.getUint8 ( position );
@@ -34,17 +40,26 @@ class SpriteSet {
             } else {
                 throw new TypeError ( 'Unsupported layout type: ' + layout );
             }
-
         } else {
             throw new TypeError ( 'Invalid file signature: ' + signature );
         }
     }
 
     constructor ( src ) {
+        super ();
+        
         if ( typeof src === 'string' ) {
             fsp.readFile ( src ).then ( data => {
-                return SpriteSet.fromBuffer ( data.buffer );
+                Object.assign ( this, SpriteSet.fromBuffer ( data.buffer ) );
+                this.dispatchEvent ( new Event ( 'load' ) )
             } );
         }
+
+        this.type = '';
+        this.width = 0;
+        this.height = 0;
+        this.positions = [];
+        this.tiles = [];
+        this.palette = [];
     }
 }

--- a/editor/test/js/SpriteSet.js
+++ b/editor/test/js/SpriteSet.js
@@ -1,65 +1,73 @@
-const fsp = require ( 'fs/promises' );
+const   fsp = require ( 'fs/promises' ),
+        zlib = require ( 'zlib' );
 
 /**
-  * loads a Sprite Engine tile set of positioned 16x16 tiles.
+  * Loads a Sprite Engine tile set of 16x16 tiles.
   *
   * SpriteSet file format:
   * extension - .sps
   * signature - "SPRENGSET"
-  * layout type - <byte> 0 (defualt) positioned, 1 fixed
-  * position count - <int32>
-  * packed position size - <int32>
-  * tile count - <int32>
-  * packed tile size <int32>
-  * palette length - <uint8>
-  * packed palette size - <int32>
-  * packed position data - <unit8>
-  * packed tile data - <uint8>
-  * packed palette data - <uint8>
+  * layout type - <byte> 0 (default) positioned, 1 fixed
+  * width - <unint8> width in tiles
+  * height - <unit8> height in tiles
+  * position count - <uint16> number of tile positions ( unit8 [ x, y, index ] )
+  * tile count - <unit8> number of unique tiles ( 16x16 RGBA )
+  * palette length - <uint8> number of palette colors ( unit8 RGBA )
+  * zlib/deflate chunk - <unit8> buffer of positions ( if layout type 0 ),
+  *     tiles, palette colors
   */
 
-class SpriteSet extends EventTarget {
+module.exports = class SpriteSet extends EventTarget {
     static POSITIONED = 0;
     static FIXED = 1;
     static TYPE = {
         0: 'POSITIONED',
         1: 'FIXED'
     };
+    static SIGNATURE_SIZE = 9;
+    static SIGNATURE = 'SPRENGSET';
+    static TILE_SIZE = 256;
+    static COLOR_SIZE = 4;
 
     static fromBuffer ( buffer ) {
-        let uint8 = new Uint8Array ( data.buffer ),
+        let view = new DataView ( buffer ),
             position = 0,
-            signature =  String.fromCharCodes ( ...uint8.slice ( 0, 9 ) );
-        if ( singature === 'SPRENGSET' ) {
+            signature =  String.fromCharCodes ( ...new Uint8Array ( buffer.slice ( 0, SpriteSet.SIGNATURE_SIZE ) ) );
+        if ( singature === SpriteSet.SIGNATURE ) {
             position += signature.length;
-            let view = new DataView ( data.buffer ),
-                spriteSet = new SpriteSet (),
-                layout = view.getUint8 ( position );
+            let spriteSet = new SpriteSet (),
+                layout = view.getUint8 ( position++ );
             if ( layout in SpriteSet.TYPE ) {
                 spriteSet.type = SpriteSet.TYPE [ layout ];
             } else {
                 throw new TypeError ( 'Unsupported layout type: ' + layout );
             }
         } else {
-            throw new TypeError ( 'Invalid file signature: ' + signature );
+            throw new TypeError ( `SpriteSet: invalid file signature - "${signature}"` );
         }
     }
 
+    #complete = false;
+
     constructor ( src ) {
         super ();
-        
+
         if ( typeof src === 'string' ) {
             fsp.readFile ( src ).then ( data => {
-                Object.assign ( this, SpriteSet.fromBuffer ( data.buffer ) );
-                this.dispatchEvent ( new Event ( 'load' ) )
+                SpriteSet.fromBuffer ( data.buffer ).then ( spriteSet => {
+                    Object.assign ( this, spriteSet );
+                    this.dispatchEvent ( new Event ( 'load' ) );
+                } );
             } );
         }
 
         this.type = '';
         this.width = 0;
         this.height = 0;
-        this.positions = [];
-        this.tiles = [];
-        this.palette = [];
+        this.positions = null;
+        this.tiles = null;
+        this.palette = null;
+
+        this.addEventListener ( 'load', event => this.#complete = true );
     }
 }

--- a/editor/test/js/brushes.js
+++ b/editor/test/js/brushes.js
@@ -1,0 +1,146 @@
+const   fsp = require ( 'fs/promises' ),
+        zlib = require ( 'zlib' ),
+        SpriteSet = require ( './SpriteSet' );
+
+/**
+  * A multi-layered Sprite Engine raw brush data object with no associated
+  * Sprite Engine SpriteSet. Used by Sprite Engine SpriteBrushSet.
+  */
+
+class SpriteBrush {
+    constructor ( width, height, layers, data ) {
+        this.width = width;
+        this.height = height;
+        this.layers = [];
+        if ( data ) {
+            if ( data.buffer && data.buffer.constructor === ArrayBuffer ) {
+                data = data.buffer;
+            } else if ( Array.isArray ( data ) ) {
+                data = new Uint8Array ( data ).buffer;
+            } else if ( data.constructor !== ArrayBuffer ) {
+                throw new TypeError ( 'SpriteBrush: unsupported data object - ' + Object.prototype.toString.call ( data ) );
+            }
+        } else {
+            throw new TypeError ( 'SpriteBrush: invalid argument "data" - ' + Object.prototype.toString.call ( data ) );
+        }
+
+        let offset = 0, length = width * height;
+        for ( let i = 0; i < layers; i = i + 1 ) {
+            this.layers.push ( new Uint8Array ( data, offset, length ) );
+            offset += length;
+        }
+    }
+
+    set ( x, y, depth, data ) {
+        if ( depth < this.layers.length )
+            let offset;
+            if ( data instanceof SpriteBrush ) {
+                let layer, position, row, raw;
+                for ( layer = 0; layer < data.layers.length; layer += 1 ) {
+                    offset = y * this.width + x;
+                    if ( layer + depth < this.layers.length ) {
+                        for ( row = 0; row < data.height; row += 1 ) {
+                            if ( row + y < this.height ) {
+                                let raw = data.layers [ layer ].slice (
+                                    row * data.width, Math.min ( row * ( 1 + data.width ), row * data.width + this.width - x )
+                                );
+                                this.layers [ layer + depth ].set ( raw, offset );
+                                offset += this.width;
+                            } else { break; }
+                        }
+                    } else { break; }
+                }
+            } else if ( 'number' === typeof data ) {
+                this.layers [ depth ] [ offset ] = data;
+            }
+        }
+    }
+}
+
+/**
+  * A set of multi-layered Sprite Engine brushes associated with an included
+  * Sprite Engine SpriteSet.
+  *
+  * When loaded from a file, if the `src` argument to the constructor is a
+  * string referring to the path of a SpriteBrush file, a file name is included
+  * in the file to refer to a Sprite Engine SpriteSet.  The SpriteSet file must
+  * be in the same folder as the SpriteBrush file or no SpriteSet will be
+  * loaded. Alternatively, a SpriteSet instance may be passed to the
+  * constructor.
+  *
+  * SpriteBrush file format:
+  * extension - .spb
+  * signature - "SPRENGBRU"
+  * brush count - <uint8> number of brushes
+  * zlib/deflate chunk - <uint8> buffer of brushes:
+  *     width - <uint8> width in tiles ( total width is brushWidth * tileWidth )
+  *     height - <uint8> height in tiles ( total height is brushHeight * tileHeight )
+  *     layers - <uint8> number of layers ( layer size is brushWidth * brushHeight ),
+  * followed by a SpriteSet ( in the same deflated chunk )
+  */
+
+class SpriteBrushSet extends EventTarget {
+    SIGNATURE_SIZE = 9;
+    SIGNATURE = "SPRENGBST";
+
+    static fromBuffer ( buffer ) {
+        let view = new DataView ( buffer ),
+            position = 0,
+            signature =  String.fromCharCodes ( ...new Uint8Array ( buffer.slice ( 0, SpriteBrush.SIGNATURE_SIZE ) ) );
+        if ( signature === SpriteBrush.SIGNATURE ) {
+            position += SpriteBrush.SIGNATURE_SIZE;
+            return new Promise ( ( resolve, reject ) => {
+                let brushCount = view.getUint8 ( position++ ),
+                    packed = buffer.slice ( position );
+                zlib.deflateRaw ( packed, ( err, data ) => {
+                    if ( err ) reject ( err );
+
+                    let view = new DataView ( data.buffer ),
+                        brushSet = new SpriteBrushSet ();
+                        i, width, height, layers, position = 0;
+
+                    brushSet.brushes = [];
+                    for ( i = 0; i < brushCount; i += 1 ) {
+                        width = view.getUint8 ( position++ );
+                        height = view.getUint8 ( position++ );
+                        layers = view.getUint8 ( position++ );
+                        data = buffer.slice ( position, position += width * height * layers );
+                        brushSet.brushes.push ( new SpriteBrush ( width, height, layers, data ) );
+                    }
+                    brushSet.spriteSet = new SpriteSet ( buffer.slice ( position ) );
+
+                    brushSet.addEventListener ( 'load', event => brushSet.dispatchEvent ( new Event ( 'load' ) ) );
+
+                    resolve ( brushSet );
+                } );
+            } );
+        } else {
+            throw new TypeError ( `SpriteBrushSet: invalid file signature - "${signature}"` );
+        }
+    }
+
+    #complete = false;
+
+    constructor ( src ) {
+        if ( typeof src === 'string' ) {
+            fsp.readFile ( src ).then ( data => {
+                SpriteBrush.fromBuffer ( data.buffer ).then ( spriteBrush => {
+                    Object.assign ( this, spriteBrush );
+                    this.dispatchEvent ( new Event ( 'load' ) );
+                } );
+            } );
+        }
+
+        this.brushes = null;
+        this.spriteSet = null;
+
+        this.addEventListener ( 'load', event => this.#complete = true );
+    }
+
+    get complete () {
+        return this.#complete;
+    }
+}
+
+module.exports.SpriteBrush = SpriteBrush;
+module.exports.SpriteBrushSet = SpriteBrushSet;


### PR DESCRIPTION
had `SpriteSet` extend `EventTarget`

improved/extended documentation for `SpriteSet`

added own properties to `SpriteSet` instances

fixed constructor returning from inside a promise, now applies loaded data to current instance and triggers "load" event